### PR TITLE
Update metadata to support puppetlabs-firewall 2.0.0 release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
         },
         {
             "name": "puppetlabs/firewall",
-            "version_requirement": ">= 1.8.0 < 2.0.0"
+            "version_requirement": ">= 1.8.0 <= 2.0.0"
         }
     ]
 }


### PR DESCRIPTION
Updated module metadata to work with latest version of the firewall module.